### PR TITLE
Update AI model to Claude Sonnet 4.5 with global inference profile

### DIFF
--- a/src/bedrock_utils.py
+++ b/src/bedrock_utils.py
@@ -11,7 +11,7 @@ logger = logging.getLogger()
 custom_retry_config = Config(retries={"max_attempts": 8, "mode": "adaptive"})
 
 bedrock_runtime = boto3.client(
-    "bedrock-runtime", region_name="us-east-1", config=custom_retry_config
+    "bedrock-runtime", region_name="us-west-2", config=custom_retry_config
 )
 
 

--- a/src/bedrock_utils.py
+++ b/src/bedrock_utils.py
@@ -11,7 +11,7 @@ logger = logging.getLogger()
 custom_retry_config = Config(retries={"max_attempts": 8, "mode": "adaptive"})
 
 bedrock_runtime = boto3.client(
-    "bedrock-runtime", region_name="us-west-2", config=custom_retry_config
+    "bedrock-runtime", region_name="ap-northeast-1", config=custom_retry_config
 )
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -5,5 +5,5 @@ DYNAMODB_TABLE_NAME = os.environ["DYNAMODB_TABLE_NAME"]
 
 # AI モデル関連
 AI_MODEL_MAX_TOKENS = 2048
-AI_MODEL_ID = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+AI_MODEL_ID = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
 AI_MODEL_VERSION = "bedrock-2023-05-31"

--- a/src/config.py
+++ b/src/config.py
@@ -5,5 +5,5 @@ DYNAMODB_TABLE_NAME = os.environ["DYNAMODB_TABLE_NAME"]
 
 # AI モデル関連
 AI_MODEL_MAX_TOKENS = 2048
-AI_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+AI_MODEL_ID = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 AI_MODEL_VERSION = "bedrock-2023-05-31"


### PR DESCRIPTION
## Summary
- Claude Sonnet 4 から Claude Sonnet 4.5 にモデルを更新
- Global inference profile を使用してスループットを最大化
- Bedrock リージョンを東京 (ap-northeast-1) に変更
- README にトラブルシューティングセクションを追加

## Changes
- `AI_MODEL_ID` を `global.anthropic.claude-sonnet-4-5-20250929-v1:0` に更新
- `bedrock_runtime` のリージョンを `ap-northeast-1` に変更
- Bedrock モデルアクセス権限のトラブルシューティング手順を README に追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)