### PR TITLE
Markdown→Slack mrkdwn変換を追加

### DIFF
--- a/src/slack_utils.py
+++ b/src/slack_utils.py
@@ -190,7 +190,10 @@ def send_slack_message(channel_id, text, thread_ts):
         messages = split_message(converted_text)
         for msg in messages:
             slack_client.chat_postMessage(
-                channel=channel_id, text=msg, thread_ts=thread_ts
+                channel=channel_id,
+                text=msg,
+                thread_ts=thread_ts,
+                blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": msg}}],
             )
     except SlackApiError as e:
         logger.error(f"Error sending message to Slack: {e}")

--- a/tests/unit/test_slack_utils.py
+++ b/tests/unit/test_slack_utils.py
@@ -181,7 +181,12 @@ def test_send_slack_message_success(mock_chat_post_message):
 
     # 検証
     mock_chat_post_message.assert_called_once_with(
-        channel="C123", text="テストメッセージ", thread_ts="1234567890.123456"
+        channel="C123",
+        text="テストメッセージ",
+        thread_ts="1234567890.123456",
+        blocks=[
+            {"type": "section", "text": {"type": "mrkdwn", "text": "テストメッセージ"}}
+        ],
     )
 
 


### PR DESCRIPTION
## Summary
- `**bold**`→`*bold*`、`*italic*`→`_italic_`等の変換を追加
- コードブロック内は変換対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)