### PR TITLE
Update AI model to Claude Opus 4.8

### DIFF
--- a/docs/bedrock_models.md
+++ b/docs/bedrock_models.md
@@ -99,3 +99,4 @@ Model access is denied due to INVALID_PAYMENT_INSTRUMENT
 | 2025-09-30 | `global.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 に更新 |
 | 2025-12-05 | `global.anthropic.claude-opus-4-5-20251101-v1:0` | より高性能な Opus 4.5 に更新 |
 | 2026-05-27 | `global.anthropic.claude-opus-4-7` | より高性能な Opus 4.7 に更新 |
+| 2026-05-30 | `global.anthropic.claude-opus-4-8` | より高性能な Opus 4.8 に更新 |

--- a/src/config.py
+++ b/src/config.py
@@ -5,7 +5,7 @@ DYNAMODB_TABLE_NAME = os.environ["DYNAMODB_TABLE_NAME"]
 
 # AI モデル関連
 AI_MODEL_MAX_TOKENS = 2048
-AI_MODEL_ID = "global.anthropic.claude-opus-4-7"
+AI_MODEL_ID = "global.anthropic.claude-opus-4-8"
 AI_MODEL_VERSION = "bedrock-2023-05-31"
 AI_SYSTEM_PROMPT = (
     "あなたはSlackチャットボットです。チャットの応答として自然な対話となるよう心がけてください。"


### PR DESCRIPTION
## 変更内容

`src/config.py` の `AI_MODEL_ID` を `global.anthropic.claude-opus-4-7` → `global.anthropic.claude-opus-4-8` に更新。

- Bedrock inference profile での疎通確認済み
- 全51テスト PASS 確認済み
- `docs/bedrock_models.md` のモデル更新履歴に追記